### PR TITLE
Pipe 66 ignore nonexistent projects

### DIFF
--- a/demo-pipeline-infra.tf
+++ b/demo-pipeline-infra.tf
@@ -1,7 +1,6 @@
 terraform {
         backend "s3" {
         bucket = "liatristorage"
-//        key = "liatristorage/${terraform.workspace}/${var.app_name}-terraform.tfstate"
         region = "us-west-2"
     }
 }

--- a/pipeline-creator.Jenkinsfile
+++ b/pipeline-creator.Jenkinsfile
@@ -204,7 +204,7 @@ pipeline {
           slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: ":white_check_mark: Pipeline for the *${PROJECT_NAME}* app successfully created :white_check_mark:", teamDomain: 'liatrio', failOnError: true
       }
       failure {
-          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "#ff0000", message: "Pipeline creator failed at stage ${STAGE_NAME}", teamDomain: 'liatrio', failOnError: true
+          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "danger", message: "Pipeline creator failed. See details here: ${env.BUILD_URL}", teamDomain: 'liatrio', failOnError: true
       }
   }
 }

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -20,16 +20,24 @@ pipeline {
           def deletePipelineHome = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-home"
           def deleteDemoApp = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-demo-application"
           def deleteProject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}"
+          if(deleteProject.status == 404){
+              slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Bitbucket project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+          }else{
+              slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Bitbucket project and repositories deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+          }
         }
-        slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Bitbucket project and repositories deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
       }
     }
     stage('Delete Jira Project') {
       steps {
         script {
           def deleteJiraPoject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://jira.liatr.io/rest/api/2/project/${PROJECT_KEY}"
+            if(deleteJiraPoject.status == 404){
+                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Jira project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+            }else{
+                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Jira project deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+            }
         }
-        slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Jira project deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
       }
     }
     stage('Delete Confluence space') {
@@ -37,8 +45,12 @@ pipeline {
       steps {
         script {
           def deleteConfluenceSpace = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
+            if(deleteConfluenceSpace.status == 404){
+                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Confluence space for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+            }else{
+                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Confluence space deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+            }
         }
-        slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Confluence space deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
       }
     }
     stage('Delete Jenkins Folder') {
@@ -55,8 +67,12 @@ pipeline {
                 customHeaders = []
             }
             def deleteJenkinsFolder = httpRequest validResponseCodes: '200,302,404', authentication: 'jenkins.liatr.io_creds', customHeaders: customHeaders, consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'POST', url: "${JENKINS_URL}/job/demo-pipelines/job/${PROJECT_NAME}/doDelete"
+            if(deleteJenkinsFolder.status == 404){
+                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Jenkins folder for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+            }else{
+                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Jenkins folder deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+            }
         }
-        slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Jenkins folder deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
       }
     }
     stage('Delete Slack Channel') {

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -134,7 +134,7 @@ pipeline {
           slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: ":negative_squared_cross_mark: The *${PROJECT_NAME}* app pipeline has been removed :negative_squared_cross_mark:", teamDomain: 'liatrio', failOnError: true
       }
       failure {
-          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "danger", message: "Pipeline destroyer failed at stage ${STAGE}", teamDomain: 'liatrio', failOnError: true
+          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "danger", message: "Pipeline destroyer failed. See details here: ${env.BUILD_URL}", teamDomain: 'liatrio', failOnError: true
       }
   }
 }

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -91,11 +91,11 @@ pipeline {
               }
             }
           }
-        }
-        if (channelFound == false) {
-          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Slack channel for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
-        } else {
-          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Slack channel deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+          if (channelFound == false) {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Slack channel for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+          } else {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Slack channel deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+          }
         }
       }
     }

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -17,9 +17,9 @@ pipeline {
         }
         slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Beginning deletion of the *${PROJECT_NAME}* app pipeline", teamDomain: 'liatrio', failOnError: true
         script {
-          def deletePipelineHome = httpRequest authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-home"
-          def deleteDemoApp = httpRequest authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-demo-application"
-          def deleteProject = httpRequest authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}"
+          def deletePipelineHome = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-home"
+          def deleteDemoApp = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-demo-application"
+          def deleteProject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}"
         }
         slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Bitbucket project and repositories deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
       }
@@ -27,7 +27,7 @@ pipeline {
     stage('Delete Jira Project') {
       steps {
         script {
-          def deleteJiraPoject = httpRequest authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://jira.liatr.io/rest/api/2/project/${PROJECT_KEY}"
+          def deleteJiraPoject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://jira.liatr.io/rest/api/2/project/${PROJECT_KEY}"
         }
         slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Jira project deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
       }
@@ -36,7 +36,7 @@ pipeline {
       agent any
       steps {
         script {
-          def deleteConfluenceSpace = httpRequest authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
+          def deleteConfluenceSpace = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
         }
         slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Confluence space deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
       }

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
             slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Destroying dashboard infrastructure. This can take ~ 1 minute", teamDomain: 'liatrio', failOnError: true
             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'Jenkins AWS Creds' ]]) {
                 git 'https://github.com/liatrio/pipeline-home.git'
-                sh "terraform init -force-copy -input=false -no-color -backend-config='key=liatristorage/${PROJECT_NAME}/dashboard-terraform.tfstate'"
+                sh "terraform init -reconfigure -input=false -no-color -backend-config='key=liatristorage/${PROJECT_NAME}/dashboard-terraform.tfstate'"
                 sh 'terraform destroy -auto-approve -no-color'
             }
             slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Dashboard for ${PROJECT_NAME} destroyed", teamDomain: 'liatrio', failOnError: true

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
       agent any
       steps {
         script {
-          def deleteConfluenceSpace = httpRequest validResponseCodes: '204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
+          def deleteConfluenceSpace = httpRequest validResponseCodes: '202, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
           if (deleteConfluenceSpace.status == 404) {
             slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Confluence space for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
           } else {

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
           terraform destroy -auto-approve -no-color
           """
         }
-        slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Dev deployment environment for ${PROJECT_NAME} has been destroyed", teamDomain: 'liatrio', failOnError: true
+        slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Dev deployment environment for ${PROJECT_NAME} has been destroyed", teamDomain: 'liatrio', failOnError: true
       }
     }
     stage('Destroy Dashboard Server') {
@@ -125,7 +125,7 @@ pipeline {
                 sh "terraform init -reconfigure -input=false -no-color -backend-config='key=liatristorage/${PROJECT_NAME}/dashboard-terraform.tfstate'"
                 sh 'terraform destroy -auto-approve -no-color'
             }
-            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Dashboard for ${PROJECT_NAME} destroyed", teamDomain: 'liatrio', failOnError: true
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Dashboard for ${PROJECT_NAME} destroyed", teamDomain: 'liatrio', failOnError: true
         }
     }
   }
@@ -134,7 +134,7 @@ pipeline {
           slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: ":negative_squared_cross_mark: The *${PROJECT_NAME}* app pipeline has been removed :negative_squared_cross_mark:", teamDomain: 'liatrio', failOnError: true
       }
       failure {
-          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "#ff0000", message: "Pipeline destroyer failed at stage ${STAGE}", teamDomain: 'liatrio', failOnError: true
+          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "danger", message: "Pipeline destroyer failed at stage ${STAGE}", teamDomain: 'liatrio', failOnError: true
       }
   }
 }

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -20,10 +20,10 @@ pipeline {
           def deletePipelineHome = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-home"
           def deleteDemoApp = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-demo-application"
           def deleteProject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}"
-          if(deleteProject.status == 404){
-              slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Bitbucket project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
-          }else{
-              slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Bitbucket project and repositories deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+          if (deleteProject.status == 404) {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Bitbucket project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+          } else {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Bitbucket project and repositories deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
           }
         }
       }
@@ -32,11 +32,11 @@ pipeline {
       steps {
         script {
           def deleteJiraPoject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://jira.liatr.io/rest/api/2/project/${PROJECT_KEY}"
-            if(deleteJiraPoject.status == 404){
-                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Jira project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
-            }else{
-                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Jira project deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
-            }
+          if (deleteJiraPoject.status == 404) {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Jira project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+          } else {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Jira project deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+          }
         }
       }
     }
@@ -45,11 +45,11 @@ pipeline {
       steps {
         script {
           def deleteConfluenceSpace = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
-            if(deleteConfluenceSpace.status == 404){
-                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Confluence space for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
-            }else{
-                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Confluence space deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
-            }
+          if (deleteConfluenceSpace.status == 404) {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Confluence space for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+          } else {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Confluence space deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+          }
         }
       }
     }
@@ -57,40 +57,46 @@ pipeline {
       agent any
       steps {
         script {
-            JENKINS_URL = "http://jenkins.liatr.io"
-            def jenkinsCrumb = httpRequest validResponseCodes: '200,404', authentication: 'jenkins.liatr.io_creds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'GET', url: "${JENKINS_URL}/crumbIssuer/api/json"
-            def customHeaders
-            if (jenkinsCrumb.status == 200){
-                def crumbJson = new JsonSlurperClassic().parseText(jenkinsCrumb.content)
-                customHeaders = [[name: crumbJson.crumbRequestField, value: crumbJson.crumb]]
-            } else {
-                customHeaders = []
-            }
-            def deleteJenkinsFolder = httpRequest validResponseCodes: '200,302,404', authentication: 'jenkins.liatr.io_creds', customHeaders: customHeaders, consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'POST', url: "${JENKINS_URL}/job/demo-pipelines/job/${PROJECT_NAME}/doDelete"
-            if(deleteJenkinsFolder.status == 404){
-                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Jenkins folder for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
-            }else{
-                slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Jenkins folder deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
-            }
+          JENKINS_URL = "http://jenkins.liatr.io"
+          def jenkinsCrumb = httpRequest validResponseCodes: '200,404', authentication: 'jenkins.liatr.io_creds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'GET', url: "${JENKINS_URL}/crumbIssuer/api/json"
+          def customHeaders
+          if (jenkinsCrumb.status == 200) {
+            def crumbJson = new JsonSlurperClassic().parseText(jenkinsCrumb.content)
+            customHeaders = [[name: crumbJson.crumbRequestField, value: crumbJson.crumb]]
+          } else {
+            customHeaders = []
+          }
+          def deleteJenkinsFolder = httpRequest validResponseCodes: '200,302,404', authentication: 'jenkins.liatr.io_creds', customHeaders: customHeaders, consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'POST', url: "${JENKINS_URL}/job/demo-pipelines/job/${PROJECT_NAME}/doDelete"
+          if (deleteJenkinsFolder.status == 404) {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Jenkins folder for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+          } else {
+            slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Jenkins folder deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+          }
         }
       }
     }
     stage('Delete Slack Channel') {
       steps {
         script {
+          def channelFound = false
           withCredentials([string(credentialsId: 'liatrio-demo-slack', variable: 'token')]) {
             def channelData = httpRequest customHeaders: [[name: 'Authorization', value: 'Bearer '+"${env.token}"]], acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'GET', url: "https://liatrio-demo.slack.com/api/channels.list"
             def channelJson = new JsonSlurperClassic().parseText(channelData.content)
             for ( prop in channelJson.channels ) {
               if ( prop.name == PROJECT_NAME ) {
                 println "Deleting ChannelID: ${prop.id}"
-                def deleteSlackChannel = httpRequest customHeaders: [[name: 'Authorization', value: 'Bearer '+"${env.token}"]], consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'POST', url: "https://liatrio-demo.slack.com/api/channels.delete?channel=${prop.id}"
+                def deleteSlackChannel = httpRequest customHeaders: [[name: 'Authorization', value: 'Bearer ' + "${env.token}"]], consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'POST', url: "https://liatrio-demo.slack.com/api/channels.delete?channel=${prop.id}"
+                channelFound = true
                 break
               }
             }
           }
         }
-        slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Slack channel deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+        if (channelFound == false) {
+          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Slack channel for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
+        } else {
+          slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "good", message: "Slack channel deleted for the ${PROJECT_NAME} app pipeline", teamDomain: 'liatrio', failOnError: true
+        }
       }
     }
     stage('Delete Dev Environment') {

--- a/pipeline-destroyer.Jenkinsfile
+++ b/pipeline-destroyer.Jenkinsfile
@@ -17,9 +17,9 @@ pipeline {
         }
         slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "A9ACB6", message: "Beginning deletion of the *${PROJECT_NAME}* app pipeline", teamDomain: 'liatrio', failOnError: true
         script {
-          def deletePipelineHome = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-home"
-          def deleteDemoApp = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-demo-application"
-          def deleteProject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}"
+          def deletePipelineHome = httpRequest validResponseCodes: '202, 204', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-home"
+          def deleteDemoApp = httpRequest validResponseCodes: '202, 204', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}/repos/pipeline-demo-application"
+          def deleteProject = httpRequest validResponseCodes: '204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://bitbucket.liatr.io/rest/api/1.0/projects/${PROJECT_KEY}"
           if (deleteProject.status == 404) {
             slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Bitbucket project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
           } else {
@@ -31,7 +31,7 @@ pipeline {
     stage('Delete Jira Project') {
       steps {
         script {
-          def deleteJiraPoject = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://jira.liatr.io/rest/api/2/project/${PROJECT_KEY}"
+          def deleteJiraPoject = httpRequest validResponseCodes: '204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://jira.liatr.io/rest/api/2/project/${PROJECT_KEY}"
           if (deleteJiraPoject.status == 404) {
             slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Jira project for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
           } else {
@@ -44,7 +44,7 @@ pipeline {
       agent any
       steps {
         script {
-          def deleteConfluenceSpace = httpRequest validResponseCodes: '200, 204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
+          def deleteConfluenceSpace = httpRequest validResponseCodes: '204, 404', authentication: 'BitbucketCreds', consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'DELETE', url: "http://confluence.liatr.io/rest/api/space/${PROJECT_KEY}"
           if (deleteConfluenceSpace.status == 404) {
             slackSend baseUrl: SLACK_URL, channel: SLACK_CHANNEL, color: "warning", message: "Confluence space for the ${PROJECT_NAME} app pipeline not found", teamDomain: 'liatrio', failOnError: true
           } else {


### PR DESCRIPTION
Made destroyer resilient to non-existent project
Changed slack messages indicate whether projects were found or not
Changed destroyer to use reconfigure instead of force-copy